### PR TITLE
POST - Articles

### DIFF
--- a/src/main/java/org/ieeervce/api/siterearnouveau/controller/ArticlesController.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/controller/ArticlesController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,7 +33,7 @@ public class ArticlesController {
     }
 
     @PostMapping()
-    ResultsDTO<Boolean> saveArticle(Article article) {
+    ResultsDTO<Boolean> saveArticle(@RequestBody Article article) {
         var result = articleService.saveArticle(article);
         return new ResultsDTO<>(result);
     }

--- a/src/main/java/org/ieeervce/api/siterearnouveau/entity/Article.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/entity/Article.java
@@ -3,6 +3,8 @@ package org.ieeervce.api.siterearnouveau.entity;
 import java.time.LocalDateTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Data;
@@ -12,6 +14,7 @@ import lombok.Data;
 @Data
 public class Article {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "arid")
     Integer articleId;
     


### PR DESCRIPTION
Identity-type generated columns allow autogenerated indices. `Sequence` also works, but we need to give the sequence name (annoying).
Also, added the RequestBody decorator so it binds to the request body.