### PR TITLE
Add Jacoco and Sonar

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         jacoco-csv-file: build/reports/jacoco/test/jacocoTestReport.csv
         intervals: 100 90 80 70 60 0
-        fail-if-coverage-less-than: 50
+        fail-if-coverage-less-than: 0
     - name: Upload JaCoCo coverage report
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,4 +36,6 @@ jobs:
       uses: cicirello/jacoco-badge-generator@v2.11.0
       with:
         jacoco-csv-file: build/reports/jacoco/test/jacocoTestReport.csv
+        intervals: 100 90 80 70 60 0
+        fail-if-coverage-less-than: 0
             

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,4 +38,9 @@ jobs:
         jacoco-csv-file: build/reports/jacoco/test/jacocoTestReport.csv
         intervals: 100 90 80 70 60 0
         fail-if-coverage-less-than: 0
+    - name: Upload JaCoCo coverage report
+      uses: actions/upload-artifact@v2
+      with:
+        name: jacoco-report
+        path: target/site/jacoco/
             

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,15 +23,30 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'
-    - name: Build with Gradle
-      uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
+    - name: Cache SonarCloud packages
+      uses: actions/cache@v3
       with:
-        arguments: build jacocoTestReport
+        path: ~/.sonar/cache
+        key: ${{ runner.os }}-sonar
+        restore-keys: ${{ runner.os }}-sonar
+    - name: Cache Gradle packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
+    - name: Build and analyze
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: ./gradlew build jacocoTestReport sonar --info
     - name: jacoco-badge-generator
       uses: cicirello/jacoco-badge-generator@v2.11.0
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -51,9 +51,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: ./gradlew sonar --info
-    - name: jacoco-badge-generator
-      uses: cicirello/jacoco-badge-generator@v2.11.0
-      with:
-        jacoco-csv-file: build/reports/jacoco/test/jacocoTestReport.csv
-        intervals: 100 90 80 70 60 0
-        fail-if-coverage-less-than: 0
+    # - name: jacoco-badge-generator
+    #   uses: cicirello/jacoco-badge-generator@v2.11.0
+    #   with:
+    #     jacoco-csv-file: build/reports/jacoco/test/jacocoTestReport.csv
+    #     intervals: 100 90 80 70 60 0
+    #     fail-if-coverage-less-than: 0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -40,9 +40,7 @@ jobs:
         fail-if-coverage-less-than: 0
     - name: Check artifacts
       run: |
-        ls -l target
-        ls -l target/site
-        ls -l target/site/jacoco/
+        ls -l .
     - name: Upload JaCoCo coverage report
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,12 +38,3 @@ jobs:
         jacoco-csv-file: build/reports/jacoco/test/jacocoTestReport.csv
         intervals: 100 90 80 70 60 0
         fail-if-coverage-less-than: 0
-    - name: Check artifacts
-      run: |
-        ls -l .
-    - name: Upload JaCoCo coverage report
-      uses: actions/upload-artifact@v2
-      with:
-        name: jacoco-report
-        path: build/reports/jacoco/test/
-            

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,5 +45,5 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: jacoco-report
-        path: target/site/jacoco/
+        path: build/reports/jacoco/test/
             

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,11 +42,15 @@ jobs:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
-    - name: Build and analyze
+    - name: Build
+      run: ./gradlew build
+    - name: Test and Coverage report
+      run: ./gradlew jacocoTestReport
+    - name: Analyze
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: ./gradlew build jacocoTestReport sonar --info
+      run: ./gradlew sonar --info
     - name: jacoco-badge-generator
       uses: cicirello/jacoco-badge-generator@v2.11.0
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,4 +31,9 @@ jobs:
     - name: Build with Gradle
       uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
       with:
-        arguments: build
+        arguments: build jacocoTestReport
+    - name: jacoco-badge-generator
+      uses: cicirello/jacoco-badge-generator@v2.11.0
+      with:
+        jacoco-csv-file: build/reports/jacoco/test/jacocoTestReport.csv
+            

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,7 +37,7 @@ jobs:
       with:
         jacoco-csv-file: build/reports/jacoco/test/jacocoTestReport.csv
         intervals: 100 90 80 70 60 0
-        fail-if-coverage-less-than: 0
+        fail-if-coverage-less-than: 50
     - name: Upload JaCoCo coverage report
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,6 +38,11 @@ jobs:
         jacoco-csv-file: build/reports/jacoco/test/jacocoTestReport.csv
         intervals: 100 90 80 70 60 0
         fail-if-coverage-less-than: 0
+    - name: Check artifacts
+      run: |
+        ls -l target
+        ls -l target/site
+        ls -l target/site/jacoco/
     - name: Upload JaCoCo coverage report
       uses: actions/upload-artifact@v2
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.3'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 	id 'jacoco'
+	id "org.sonarqube" version "4.4.1.3373"
 }
 
 group = 'org.ieee-rvce.api'
@@ -57,4 +58,12 @@ jacocoTestReport {
 tasks.named('asciidoctor') {
 	inputs.dir snippetsDir
 	dependsOn test
+}
+
+sonar {
+  properties {
+    property "sonar.projectKey", "IEEE-RVCE_reforseti"
+    property "sonar.organization", "ieee-rvce"
+    property "sonar.host.url", "https://sonarcloud.io"
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ tasks.named('test') {
 jacocoTestReport {
     dependsOn test // tests are required to run before generating the report
 	reports {
-		csv.required = true
+		xml.required = true
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'org.springframework.boot' version '3.1.3'
 	id 'io.spring.dependency-management' version '1.1.3'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
+	id 'jacoco'
 }
 
 group = 'org.ieee-rvce.api'
@@ -44,6 +45,13 @@ dependencies {
 tasks.named('test') {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
+}
+
+jacocoTestReport {
+    dependsOn test // tests are required to run before generating the report
+	reports {
+		csv.required = true
+    }
 }
 
 tasks.named('asciidoctor') {


### PR DESCRIPTION
Use jacoco and sonarcloud for coverage and code analysis.

Code coverage is now also seen as part of the Github PR comments, if applicable. 

Closes #12 