### PR TITLE
[ops] Creates prometheus endpoint and add cors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,65 +1,72 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.11'
-	id 'io.spring.dependency-management' version '1.1.4'
-	id 'jacoco'
-	id "org.sonarqube" version "4.4.1.3373"
+    id 'java'
+    id 'org.springframework.boot' version '3.1.11'
+    id 'io.spring.dependency-management' version '1.1.4'
+    id 'jacoco'
+    id "org.sonarqube" version "4.4.1.3373"
+    id "com.gorylenko.gradle-git-properties" version "2.4.+"
 }
 
 group = 'org.ieee-rvce.api'
 version = '0.1.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
+}
+
+springBoot {
+    buildInfo()
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
-bootJar{
-	exclude('application-local.properties')
+bootJar {
+    exclude('application-local.properties')
 }
 
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'com.auth0:java-jwt:4.4.0'
-	implementation 'org.modelmapper:modelmapper:3.2.0'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.postgresql:postgresql'
-	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'com.h2database:h2'
+    compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'com.auth0:java-jwt:4.4.0'
+    implementation 'org.modelmapper:modelmapper:3.2.0'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+    runtimeOnly 'org.postgresql:postgresql'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
-	maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    useJUnitPlatform()
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
 jacocoTestReport {
     dependsOn test // tests are required to run before generating the report
-	reports {
-		xml.required = true
+    reports {
+        xml.required = true
     }
 }
 
 sonar {
-  properties {
-    property "sonar.projectKey", "IEEE-RVCE_reforseti"
-    property "sonar.organization", "ieee-rvce"
-    property "sonar.host.url", "https://sonarcloud.io"
-  }
+    properties {
+        property "sonar.projectKey", "IEEE-RVCE_reforseti"
+        property "sonar.organization", "ieee-rvce"
+        property "sonar.host.url", "https://sonarcloud.io"
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'org.modelmapper:modelmapper:3.2.0'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'

--- a/src/main/java/org/ieeervce/api/siterearnouveau/config/CorsConfig.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/config/CorsConfig.java
@@ -12,6 +12,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -33,36 +34,28 @@ public class CorsConfig {
     @Profile("local")
     @ConditionalOnProperty("cors.local.origin")
     CorsConfigurationSource corsConfigurationSource(@Value("${cors.local.origin}") String origin) {
-        LOGGER.info("Using local cors config, with origin={}",origin);
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.addAllowedOrigin(origin);
-
-        configuration.setAllowCredentials(true);
-        configuration.addAllowedMethod("GET");
-        configuration.addAllowedMethod("POST");
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-
-        return source;
+        List<String> originList = Collections.singletonList(origin);
+        return getUrlBasedCorsConfigurationSource(originList);
     }
+
+
 
     @Bean("reforsetiCorsConfig")
     @Profile("!local")
     CorsConfigurationSource regularCorsConfiguration() {
-        LOGGER.info("Started non-local cors config with origin={}",PRODUCTION_ALLOWED_ORIGINS);
+        return getUrlBasedCorsConfigurationSource(PRODUCTION_ALLOWED_ORIGINS);
+    }
+
+    private UrlBasedCorsConfigurationSource getUrlBasedCorsConfigurationSource(List<String> originList) {
+        LOGGER.info("Using cors config, with origins={}", originList);
         CorsConfiguration configuration = new CorsConfiguration();
 
-        PRODUCTION_ALLOWED_ORIGINS.forEach(configuration::addAllowedOrigin);
-
+        originList.forEach(configuration::addAllowedOrigin);
         configuration.setAllowCredentials(true);
-        configuration.addAllowedMethod("GET");
-        configuration.addAllowedMethod("POST");
+        configuration.applyPermitDefaultValues();
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
-        LOGGER.info("Ended cors config");
-
         return source;
     }
 

--- a/src/main/java/org/ieeervce/api/siterearnouveau/config/CorsConfig.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/config/CorsConfig.java
@@ -1,0 +1,69 @@
+package org.ieeervce.api.siterearnouveau.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * Conditional Cors.
+ * When using the local profile, we use a configurable value.
+ * When this profile is not activated, the production endpoints are used.
+ */
+@Configuration
+public class CorsConfig {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CorsConfig.class);
+    private static final List<String> PRODUCTION_ALLOWED_ORIGINS = Arrays.asList(
+            "https://ieee-rvce.org",
+            "https://www.ieee-rvce.org",
+            "https://csitss.ieee-rvce.org"
+    );
+
+    @Bean("reforsetiCorsConfig")
+    @Profile("local")
+    @ConditionalOnProperty("cors.local.origin")
+    CorsConfigurationSource corsConfigurationSource(@Value("${cors.local.origin}") String origin) {
+        LOGGER.info("Using local cors config, with origin={}",origin);
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOrigin(origin);
+
+        configuration.setAllowCredentials(true);
+        configuration.addAllowedMethod("GET");
+        configuration.addAllowedMethod("POST");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+
+    @Bean("reforsetiCorsConfig")
+    @Profile("!local")
+    CorsConfigurationSource regularCorsConfiguration() {
+        LOGGER.info("Started non-local cors config with origin={}",PRODUCTION_ALLOWED_ORIGINS);
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        PRODUCTION_ALLOWED_ORIGINS.forEach(configuration::addAllowedOrigin);
+
+        configuration.setAllowCredentials(true);
+        configuration.addAllowedMethod("GET");
+        configuration.addAllowedMethod("POST");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        LOGGER.info("Ended cors config");
+
+        return source;
+    }
+
+}

--- a/src/main/java/org/ieeervce/api/siterearnouveau/controller/ArticlesController.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/controller/ArticlesController.java
@@ -3,6 +3,7 @@ package org.ieeervce.api.siterearnouveau.controller;
 import java.util.List;
 import java.util.Optional;
 
+import io.micrometer.core.annotation.Timed;
 import org.ieeervce.api.siterearnouveau.dto.ResultsDTO;
 import org.ieeervce.api.siterearnouveau.dto.article.ArticleDTO;
 import org.ieeervce.api.siterearnouveau.entity.Article;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/article")
+@Timed
 public class ArticlesController {
     private final ArticleService articleService;
     private final ModelMapper modelMapper;

--- a/src/main/java/org/ieeervce/api/siterearnouveau/controller/AuthController.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/controller/AuthController.java
@@ -1,5 +1,6 @@
 package org.ieeervce.api.siterearnouveau.controller;
 
+import io.micrometer.core.annotation.Timed;
 import jakarta.servlet.http.HttpServletRequest;
 import org.ieeervce.api.siterearnouveau.auth.AuthUserDetails;
 import org.ieeervce.api.siterearnouveau.dto.ResultsDTO;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
  */
 @RestController
 @RequestMapping("/api/auth")
+@Timed
 public class AuthController {
     private final AuthenticationManager authenticationManager;
 

--- a/src/main/java/org/ieeervce/api/siterearnouveau/controller/EventsController.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/controller/EventsController.java
@@ -2,6 +2,7 @@ package org.ieeervce.api.siterearnouveau.controller;
 
 import java.util.List;
 
+import io.micrometer.core.annotation.Timed;
 import org.ieeervce.api.siterearnouveau.dto.ResultsDTO;
 import org.ieeervce.api.siterearnouveau.dto.event.EventDTO;
 import org.ieeervce.api.siterearnouveau.entity.Event;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/event")
+@Timed
 public class EventsController {
     private final EventsService eventsService;
     private final ModelMapper modelMapper;

--- a/src/main/java/org/ieeervce/api/siterearnouveau/controller/ExecomMembersController.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/controller/ExecomMembersController.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import io.micrometer.core.annotation.Timed;
 import org.ieeervce.api.siterearnouveau.dto.ResultsDTO;
 import org.ieeervce.api.siterearnouveau.dto.execom.ExecomMemberDTO;
 import org.ieeervce.api.siterearnouveau.entity.ExecomMember;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/execom")
+@Timed
 public class ExecomMembersController {
 
     private ExecomMembersService execomMembersService;

--- a/src/main/java/org/ieeervce/api/siterearnouveau/controller/ImagesController.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/controller/ImagesController.java
@@ -1,5 +1,6 @@
 package org.ieeervce.api.siterearnouveau.controller;
 
+import io.micrometer.core.annotation.Timed;
 import org.ieeervce.api.siterearnouveau.dto.ResultsDTO;
 import org.ieeervce.api.siterearnouveau.dto.image.ImageDescriptionDTO;
 import org.ieeervce.api.siterearnouveau.entity.Image;
@@ -16,6 +17,7 @@ import java.util.stream.Stream;
 
 @RestController
 @RequestMapping("/api/image")
+@Timed
 public class ImagesController {
     private ImageService imageService;
     private ModelMapper modelMapper;

--- a/src/main/java/org/ieeervce/api/siterearnouveau/controller/SocietiesController.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/controller/SocietiesController.java
@@ -1,5 +1,6 @@
 package org.ieeervce.api.siterearnouveau.controller;
 
+import io.micrometer.core.annotation.Timed;
 import org.ieeervce.api.siterearnouveau.dto.ResultsDTO;
 import org.ieeervce.api.siterearnouveau.dto.society.SocietyDTO;
 import org.ieeervce.api.siterearnouveau.entity.Society;
@@ -14,6 +15,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/society")
+@Timed
 public class SocietiesController {
     private static final Logger LOGGER = LoggerFactory.getLogger(SocietiesController.class);
     private final SocietyService societyService;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,14 @@
 management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
   endpoint:
     health:
       show-details: when-authorized
+    prometheus:
+      enabled: true
+
+cors:
+  local:
+    origin: http://localhost:3000


### PR DESCRIPTION
- Added build info and git properties. This way, we populate the info endpoint with our current build.
- Add cors. For local, a configuration is exposed. Otherwise, a static list is used.
- Add a prometheus endpoint. It requires credentials right now.
- Add `@Timed` annotations to get metrics on every endpoint