### PR TITLE
Register endpoint and error handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'org.modelmapper:modelmapper:3.2.0'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 }
 
 bootJar {
-    exclude('application-local.properties')
+    exclude('application-local.yml')
 }
 
 

--- a/src/main/java/org/ieeervce/api/siterearnouveau/controller/AuthController.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/controller/AuthController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import org.ieeervce.api.siterearnouveau.auth.AuthUserDetails;
 import org.ieeervce.api.siterearnouveau.dto.ResultsDTO;
 import org.ieeervce.api.siterearnouveau.dto.auth.UserRegistrationDTO;
+import org.ieeervce.api.siterearnouveau.dto.auth.UserRegistrationResponseDTO;
 import org.ieeervce.api.siterearnouveau.dto.auth.UsernamePasswordDTO;
 import org.ieeervce.api.siterearnouveau.entity.AuthToken;
 import org.ieeervce.api.siterearnouveau.entity.User;
@@ -78,14 +79,14 @@ public class AuthController {
     }
 
     @PostMapping("/register")
-    ResultsDTO<UserRegistrationDTO> register(@RequestBody @Valid UserRegistrationDTO userRegistrationDTO) throws DataExistsException {
+    ResultsDTO<UserRegistrationResponseDTO> register(@RequestBody @Valid UserRegistrationDTO userRegistrationDTO) throws DataExistsException {
         User user = modelMapper.map(userRegistrationDTO,User.class);
         String encodedPassword = passwordEncoder.encode(userRegistrationDTO.getPassword());
         user.setPassword(encodedPassword);
         user.setPicture(new byte[0]);
         LOGGER.debug("Finished password encode for new user={}",user.getUserId());
         authUserDetailsService.createIfNotExists(user);
-        return new ResultsDTO<>(userRegistrationDTO);
+        return new ResultsDTO<>(new UserRegistrationResponseDTO(user.getUserId()));
     }
 }
 

--- a/src/main/java/org/ieeervce/api/siterearnouveau/controller/error/ExceptionControllerAdvice.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/controller/error/ExceptionControllerAdvice.java
@@ -1,0 +1,43 @@
+package org.ieeervce.api.siterearnouveau.controller.error;
+
+import org.ieeervce.api.siterearnouveau.dto.ResultsDTO;
+import org.ieeervce.api.siterearnouveau.exception.DataNotFoundException;
+import org.ieeervce.api.siterearnouveau.exception.LoginFailedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.Arrays;
+
+@ControllerAdvice
+public class ExceptionControllerAdvice {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionControllerAdvice.class);
+
+
+    @ExceptionHandler({LoginFailedException.class, DataNotFoundException.class})
+    public ResponseEntity<ResultsDTO<Void>> loginErrorHandler(Exception exception) {
+        HttpStatus status = getStatusFromClassAnnotation(exception);
+        return ResponseEntity
+                .status(status.value())
+                .body(
+                        new ResultsDTO<>(false, null, exception.getLocalizedMessage())
+                );
+    }
+
+    private HttpStatus getStatusFromClassAnnotation(Exception exception) {
+        return Arrays.stream(exception.getClass().getAnnotationsByType(ResponseStatus.class))
+                .findFirst()
+                .map(ResponseStatus::value)
+                .orElseGet(this::getDefaultExceptionStatus);
+    }
+
+    private HttpStatus getDefaultExceptionStatus() {
+        LOGGER.error("Failed to get exception status. Using fallback response status");
+        return HttpStatus.I_AM_A_TEAPOT;
+    }
+
+}

--- a/src/main/java/org/ieeervce/api/siterearnouveau/controller/error/ExceptionControllerAdvice.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/controller/error/ExceptionControllerAdvice.java
@@ -1,6 +1,7 @@
 package org.ieeervce.api.siterearnouveau.controller.error;
 
 import org.ieeervce.api.siterearnouveau.dto.ResultsDTO;
+import org.ieeervce.api.siterearnouveau.exception.DataExistsException;
 import org.ieeervce.api.siterearnouveau.exception.DataNotFoundException;
 import org.ieeervce.api.siterearnouveau.exception.LoginFailedException;
 import org.slf4j.Logger;
@@ -18,7 +19,7 @@ public class ExceptionControllerAdvice {
     private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionControllerAdvice.class);
 
 
-    @ExceptionHandler({LoginFailedException.class, DataNotFoundException.class})
+    @ExceptionHandler({LoginFailedException.class, DataNotFoundException.class, DataExistsException.class})
     public ResponseEntity<ResultsDTO<Void>> loginErrorHandler(Exception exception) {
         HttpStatus status = getStatusFromClassAnnotation(exception);
         return ResponseEntity

--- a/src/main/java/org/ieeervce/api/siterearnouveau/dto/auth/UserRegistrationDTO.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/dto/auth/UserRegistrationDTO.java
@@ -1,0 +1,25 @@
+package org.ieeervce.api.siterearnouveau.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import lombok.Data;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.lang.NonNull;
+
+@Data
+public class UserRegistrationDTO {
+    @NonNull
+    private Integer userId;
+    @NonNull
+    private Integer societyId;
+    @NonNull
+    private String firstName;
+
+    @NonNull
+    private String lastName;
+    @Email
+    private String email;
+    @Length(min = 6, max=127)
+    private String password;
+    @NonNull
+    private String role;
+}

--- a/src/main/java/org/ieeervce/api/siterearnouveau/dto/auth/UserRegistrationDTO.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/dto/auth/UserRegistrationDTO.java
@@ -2,10 +2,12 @@ package org.ieeervce.api.siterearnouveau.dto.auth;
 
 import jakarta.validation.constraints.Email;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 import org.springframework.lang.NonNull;
 
 @Data
+@NoArgsConstructor
 public class UserRegistrationDTO {
     @NonNull
     private Integer userId;

--- a/src/main/java/org/ieeervce/api/siterearnouveau/dto/auth/UserRegistrationResponseDTO.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/dto/auth/UserRegistrationResponseDTO.java
@@ -1,0 +1,14 @@
+package org.ieeervce.api.siterearnouveau.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.lang.NonNull;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserRegistrationResponseDTO {
+    @NonNull
+    private Integer userId;
+}

--- a/src/main/java/org/ieeervce/api/siterearnouveau/entity/User.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/entity/User.java
@@ -1,16 +1,14 @@
 package org.ieeervce.api.siterearnouveau.entity;
 
-import java.io.Serial;
-import java.io.Serializable;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.ToString;
+
+import java.io.Serial;
+import java.io.Serializable;
 
 @Entity
 @Table(name="users")
@@ -19,10 +17,10 @@ public class User implements Serializable {
     @Serial
     private static final long serialVersionUID = 100L;
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "uid")
     private Integer userId;
 
+    // TODO update the modelling to include the other table
     @Column(name = "sid")
     private Integer societyId;
 

--- a/src/main/java/org/ieeervce/api/siterearnouveau/exception/DataExistsException.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/exception/DataExistsException.java
@@ -1,0 +1,11 @@
+package org.ieeervce.api.siterearnouveau.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class DataExistsException extends Exception {
+    public DataExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/ieeervce/api/siterearnouveau/exception/LoginFailedException.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/exception/LoginFailedException.java
@@ -1,0 +1,11 @@
+package org.ieeervce.api.siterearnouveau.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class LoginFailedException extends Exception {
+    public LoginFailedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/ieeervce/api/siterearnouveau/service/AuthUserDetailsService.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/service/AuthUserDetailsService.java
@@ -17,7 +17,8 @@ import org.springframework.stereotype.Service;
 public class AuthUserDetailsService implements UserDetailsService {
 	private static final Supplier<UsernameNotFoundException> EXCEPTION_SUPPLIER = () -> new UsernameNotFoundException(
 			"Username not found");
-	private UsersRepository usersRepository;
+	static final String USER_ALREADY_EXISTS = "User already exists";
+	private final UsersRepository usersRepository;
 
 	public AuthUserDetailsService(UsersRepository usersRepository) {
 		this.usersRepository = usersRepository;
@@ -37,7 +38,7 @@ public class AuthUserDetailsService implements UserDetailsService {
 	}
 	public User createIfNotExists(User user) throws DataExistsException {
 		if(usersRepository.existsById(user.getUserId())){
-			throw new DataExistsException("User already exists");
+			throw new DataExistsException(USER_ALREADY_EXISTS);
 		}
 		return usersRepository.save(user);
 	}

--- a/src/main/java/org/ieeervce/api/siterearnouveau/service/AuthUserDetailsService.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/service/AuthUserDetailsService.java
@@ -4,6 +4,7 @@ import java.util.function.Supplier;
 
 import org.ieeervce.api.siterearnouveau.auth.AuthUserDetails;
 import org.ieeervce.api.siterearnouveau.entity.User;
+import org.ieeervce.api.siterearnouveau.exception.DataExistsException;
 import org.ieeervce.api.siterearnouveau.repository.UsersRepository;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -34,5 +35,10 @@ public class AuthUserDetailsService implements UserDetailsService {
 
 		return new AuthUserDetails(user);
 	}
-
+	public User createIfNotExists(User user) throws DataExistsException {
+		if(usersRepository.existsById(user.getUserId())){
+			throw new DataExistsException("User already exists");
+		}
+		return usersRepository.save(user);
+	}
 }

--- a/src/test/java/org/ieeervce/api/siterearnouveau/controller/AuthControllerTest.java
+++ b/src/test/java/org/ieeervce/api/siterearnouveau/controller/AuthControllerTest.java
@@ -2,35 +2,44 @@ package org.ieeervce.api.siterearnouveau.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+import org.hamcrest.Matchers;
 import org.ieeervce.api.siterearnouveau.auth.AuthUserDetails;
 import org.ieeervce.api.siterearnouveau.controller.error.ExceptionControllerAdvice;
+import org.ieeervce.api.siterearnouveau.dto.auth.UserRegistrationDTO;
 import org.ieeervce.api.siterearnouveau.dto.auth.UsernamePasswordDTO;
 import org.ieeervce.api.siterearnouveau.entity.AuthToken;
 import org.ieeervce.api.siterearnouveau.entity.User;
 import org.ieeervce.api.siterearnouveau.jwt.JWTAuthenticationFilter;
 import org.ieeervce.api.siterearnouveau.service.AuthTokenService;
+import org.ieeervce.api.siterearnouveau.service.AuthUserDetailsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -38,6 +47,7 @@ class AuthControllerTest {
     public static final String EXAMPLE_JWT = "example_jwt";
     public static final String EXAMPLE_USER_ID = "1234";
     public static final String EXAMPLE_USER_PASSWORD = "pass";
+    public static final int USER_ID = 1234;
     ObjectMapper objectMapper = new ObjectMapper();
     @Mock
     AuthenticationManager authenticationManager;
@@ -51,6 +61,12 @@ class AuthControllerTest {
     User user;
     @Mock
     AuthToken authToken;
+    @Spy
+    ModelMapper modelMapper;
+    @Spy
+    PasswordEncoder passwordEncoder;
+    @Mock
+    AuthUserDetailsService authUserDetailsService;
     UsernamePasswordDTO usernamePasswordDTO = new UsernamePasswordDTO();
 
     @InjectMocks
@@ -82,9 +98,9 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(toJsonBytes(usernamePasswordDTO))
                         .requestAttr(JWTAuthenticationFilter.AUTH_JWT_REQUEST_ATTRIBUTE, EXAMPLE_JWT))
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.ok", equalTo(true)))
-                .andExpect(jsonPath("$.response",equalTo(EXAMPLE_JWT)));
+                .andExpect(jsonPath("$.response", equalTo(EXAMPLE_JWT)));
     }
 
     @Test
@@ -96,9 +112,9 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(toJsonBytes(usernamePasswordDTO))
                         .requestAttr(JWTAuthenticationFilter.AUTH_JWT_REQUEST_ATTRIBUTE, EXAMPLE_JWT))
-                .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+                .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.ok", equalTo(false)))
-                .andExpect(jsonPath("$.message",equalTo("Failed to log in")))
+                .andExpect(jsonPath("$.message", equalTo("Failed to log in")))
                 .andExpect(jsonPath("$.response", nullValue()));
     }
 
@@ -110,9 +126,9 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(toJsonBytes(usernamePasswordDTO))
                         .requestAttr(JWTAuthenticationFilter.AUTH_JWT_REQUEST_ATTRIBUTE, EXAMPLE_JWT))
-                .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+                .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.ok", equalTo(false)))
-                .andExpect(jsonPath("$.message",equalTo("Failed to log in")))
+                .andExpect(jsonPath("$.message", equalTo("Failed to log in")))
                 .andExpect(jsonPath("$.response", nullValue()));
     }
 
@@ -120,9 +136,34 @@ class AuthControllerTest {
     void logout() throws Exception {
         mockMvc
                 .perform(delete("/api/auth").requestAttr(JWTAuthenticationFilter.AUTH_JWT_REQUEST_ATTRIBUTE, EXAMPLE_JWT))
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.ok", equalTo(true)));
         verify(authTokenService).remove(EXAMPLE_JWT);
+
+    }
+
+    @Test
+    void testRegister() throws Exception {
+        UserRegistrationDTO userRegistrationDTO = new UserRegistrationDTO();
+        userRegistrationDTO.setUserId(USER_ID);
+        userRegistrationDTO.setRole("BIG ROLE");
+        userRegistrationDTO.setPassword("myAwesomePassword");
+        userRegistrationDTO.setEmail("abcd@gmail.com");
+        userRegistrationDTO.setFirstName("First");
+        userRegistrationDTO.setLastName("Last");
+        userRegistrationDTO.setSocietyId(2);
+        ArgumentCaptor<User> userArgumentCaptor = ArgumentCaptor.forClass(User.class);
+        when(authUserDetailsService.createIfNotExists(userArgumentCaptor.capture())).thenReturn(null);
+        when(passwordEncoder.encode(anyString())).thenReturn("averyencodedpassword");
+
+        mockMvc.perform(post("/api/auth/register").contentType(MediaType.APPLICATION_JSON).content(toJsonBytes(userRegistrationDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ok", Matchers.is(true)))
+                .andExpect(jsonPath("$.response.userId", equalTo(USER_ID)));
+
+        User savedUser = userArgumentCaptor.getValue();
+        Assertions.assertThat(savedUser).isNotNull().extracting(User::getPassword).isEqualTo("averyencodedpassword");
+
 
     }
 

--- a/src/test/java/org/ieeervce/api/siterearnouveau/controller/error/ExceptionControllerAdviceTest.java
+++ b/src/test/java/org/ieeervce/api/siterearnouveau/controller/error/ExceptionControllerAdviceTest.java
@@ -1,5 +1,6 @@
 package org.ieeervce.api.siterearnouveau.controller.error;
 
+import org.ieeervce.api.siterearnouveau.exception.DataExistsException;
 import org.ieeervce.api.siterearnouveau.exception.DataNotFoundException;
 import org.ieeervce.api.siterearnouveau.exception.LoginFailedException;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +48,15 @@ class ExceptionControllerAdviceTest {
                 .andExpect(jsonPath("$.response", nullValue()));
     }
 
+    @Test
+    void testDataExists() throws Exception {
+        mockMvc.perform(get("/exists"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.ok", equalTo(false)))
+                .andExpect(jsonPath("$.response", nullValue()))
+                .andExpect(jsonPath("$.message",equalTo("Data exists")));
+    }
+
     @RestController
     private static class ExampleController {
         @GetMapping("/notfound1")
@@ -57,6 +67,11 @@ class ExceptionControllerAdviceTest {
         @GetMapping("/loginerror")
         void loginerror() throws LoginFailedException {
             throw new LoginFailedException("Failed");
+        }
+
+        @GetMapping("/exists")
+        void exists() throws DataExistsException {
+            throw new DataExistsException("Data exists");
         }
 
     }

--- a/src/test/java/org/ieeervce/api/siterearnouveau/controller/error/ExceptionControllerAdviceTest.java
+++ b/src/test/java/org/ieeervce/api/siterearnouveau/controller/error/ExceptionControllerAdviceTest.java
@@ -1,0 +1,63 @@
+package org.ieeervce.api.siterearnouveau.controller.error;
+
+import org.ieeervce.api.siterearnouveau.exception.DataNotFoundException;
+import org.ieeervce.api.siterearnouveau.exception.LoginFailedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@ExtendWith(MockitoExtension.class)
+class ExceptionControllerAdviceTest {
+    ExceptionControllerAdvice exceptionControllerAdvice;
+    MockMvc mockMvc;
+    @BeforeEach
+    void setup() {
+        exceptionControllerAdvice = new ExceptionControllerAdvice();
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new ExampleController())
+
+                .setControllerAdvice(exceptionControllerAdvice)
+                .build();
+    }
+
+    @Test
+    void testNotFoundErrorHandling() throws Exception {
+        mockMvc.perform(get("/notfound1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.ok", equalTo(false)))
+                .andExpect(jsonPath("$.response", nullValue()));
+    }
+    @Test
+    void testLoginErrorHandling() throws Exception {
+        mockMvc.perform(get("/loginerror"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.ok", equalTo(false)))
+                .andExpect(jsonPath("$.response", nullValue()));
+    }
+
+    @RestController
+    private static class ExampleController {
+        @GetMapping("/notfound1")
+        void notFound() throws DataNotFoundException {
+            throw new DataNotFoundException();
+        }
+
+        @GetMapping("/loginerror")
+        void loginerror() throws LoginFailedException {
+            throw new LoginFailedException("Failed");
+        }
+
+    }
+}

--- a/src/test/java/org/ieeervce/api/siterearnouveau/repository/UsersRepositoryTest.java
+++ b/src/test/java/org/ieeervce/api/siterearnouveau/repository/UsersRepositoryTest.java
@@ -20,6 +20,7 @@ class UsersRepositoryTest {
     private static final String LASTNAME = "CDE";
     private static final String FIRSTNAME = "ABC";
     private static final String EMAIL = "abc@example.com";
+    public static final int USER_ID = 10;
     @Autowired
     UsersRepository usersRepository;
 
@@ -27,6 +28,7 @@ class UsersRepositoryTest {
     @Transactional
     void saveUserWorks() {
         var user = new User();
+        user.setUserId(USER_ID);
         user.setEmail(EMAIL);
         user.setFirstName(FIRSTNAME);
         user.setLastName(LASTNAME);
@@ -35,9 +37,9 @@ class UsersRepositoryTest {
         user.setSocietyId(null);
         user.setPassword(PASSWORD);
 
-        var createdUser = usersRepository.save(user);
+        User createdUser = usersRepository.save(user);
 
-        assertThat(createdUser.getUserId()).isNotNull().isInstanceOf(Integer.class);
+        assertThat(createdUser.getUserId()).isNotNull().isInstanceOf(Integer.class).isEqualTo(USER_ID);
         assertThat(createdUser.getEmail()).isEqualTo(EMAIL);
         assertThat(createdUser.getFirstName()).isEqualTo(FIRSTNAME);
         assertThat(createdUser.getLastName()).isEqualTo(LASTNAME);


### PR DESCRIPTION
First, this change adds a custom login failure exception.

Second, added a registration endpoint.

Third, the (two) custom exceptions will now be handled correctly, reporting their annotated status and a message (if applicable).

Eg. Login error will now respond with the correct response status `401` and body as:
```json
{
  "ok":false,
  "response":null,
  "message":"Failed to log in"
}
```


Notable differences in new API:
- Picture is no longer accepted. Nobody used it, and it is set to empty.