### PR TITLE
Input Validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 ### Custom ###
 .env
 *.rest
-src/main/resources/application-local.properties
+src/main/resources/application-local.yml
 
 ### General ###
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Reference API Document: [api-ref.md](https://github.com/IEEE-RVCE/site-rear/blob
 
 ## Key differences
 
-- The API return shape is now more regular. Refer `ResultsDTO`
+- API field names have been updated and API shape has been normalized.
+  - This is just the consequence of using a strongly typed language.
 - API verbs have been normalized. 
   - Eg.`events` is now `event`
 - JWTs expire after some time.
-- Data field names have been updated to be more readable.
 
 ## New
 

--- a/README.md
+++ b/README.md
@@ -57,4 +57,3 @@ Reference API Document: [api-ref.md](https://github.com/IEEE-RVCE/site-rear/blob
 ## Current Implementation Notes ~~Hacks~~
 
 - JWT and Basic auth supported
-- CORS is disabled.

--- a/src/main/java/org/ieeervce/api/siterearnouveau/auth/AuthUserDetails.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/auth/AuthUserDetails.java
@@ -1,20 +1,19 @@
 package org.ieeervce.api.siterearnouveau.auth;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
-
 import org.ieeervce.api.siterearnouveau.entity.User;
-import org.springframework.security.core.CredentialsContainer;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
 
 /**
  * Provide details on User, used by Spring
  */
 public class AuthUserDetails implements UserDetails {
-    private User user;
+    private final User user;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/org/ieeervce/api/siterearnouveau/controller/error/ExceptionControllerAdvice.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/controller/error/ExceptionControllerAdvice.java
@@ -8,15 +8,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 @ControllerAdvice
 public class ExceptionControllerAdvice {
     private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionControllerAdvice.class);
+    static final String BAD_INPUT = "Bad Input";
 
 
     @ExceptionHandler({LoginFailedException.class, DataNotFoundException.class, DataExistsException.class})
@@ -27,6 +33,19 @@ public class ExceptionControllerAdvice {
                 .body(
                         new ResultsDTO<>(false, null, exception.getLocalizedMessage())
                 );
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResultsDTO<Map<String,String>>> formatErrorHandler(MethodArgumentNotValidException exception){
+        Map<String, String> errors = new HashMap<>();
+        for (ObjectError error : exception.getBindingResult().getAllErrors()) {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        }
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ResultsDTO<>(false,errors, BAD_INPUT)) ;
     }
 
     private HttpStatus getStatusFromClassAnnotation(Exception exception) {

--- a/src/main/java/org/ieeervce/api/siterearnouveau/dto/auth/UserRegistrationDTO.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/dto/auth/UserRegistrationDTO.java
@@ -12,7 +12,7 @@ import org.hibernate.validator.constraints.Length;
 @NoArgsConstructor
 public class UserRegistrationDTO {
     @NotNull
-    @Min(99_999)
+    @Min(100_000)
     private Integer userId;
     @NotNull
     private Integer societyId;

--- a/src/main/java/org/ieeervce/api/siterearnouveau/dto/auth/UserRegistrationDTO.java
+++ b/src/main/java/org/ieeervce/api/siterearnouveau/dto/auth/UserRegistrationDTO.java
@@ -1,27 +1,32 @@
 package org.ieeervce.api.siterearnouveau.dto.auth;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
-import org.springframework.lang.NonNull;
 
 @Data
 @NoArgsConstructor
 public class UserRegistrationDTO {
-    @NonNull
+    @NotNull
+    @Min(99_999)
     private Integer userId;
-    @NonNull
+    @NotNull
     private Integer societyId;
-    @NonNull
+    @NotBlank
     private String firstName;
 
-    @NonNull
+    @NotNull
     private String lastName;
     @Email
+    @NotBlank
     private String email;
     @Length(min = 6, max=127)
+    @NotNull
     private String password;
-    @NonNull
+    @NotBlank
     private String role;
 }

--- a/src/test/java/org/ieeervce/api/siterearnouveau/controller/AuthControllerTest.java
+++ b/src/test/java/org/ieeervce/api/siterearnouveau/controller/AuthControllerTest.java
@@ -47,7 +47,7 @@ class AuthControllerTest {
     public static final String EXAMPLE_JWT = "example_jwt";
     public static final String EXAMPLE_USER_ID = "1234";
     public static final String EXAMPLE_USER_PASSWORD = "pass";
-    public static final int USER_ID = 1234;
+    public static final int USER_ID = 12345678;
     ObjectMapper objectMapper = new ObjectMapper();
     @Mock
     AuthenticationManager authenticationManager;

--- a/src/test/java/org/ieeervce/api/siterearnouveau/controller/error/ExceptionControllerAdviceTest.java
+++ b/src/test/java/org/ieeervce/api/siterearnouveau/controller/error/ExceptionControllerAdviceTest.java
@@ -1,5 +1,8 @@
 package org.ieeervce.api.siterearnouveau.controller.error;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import org.hamcrest.Matchers;
 import org.ieeervce.api.siterearnouveau.exception.DataExistsException;
 import org.ieeervce.api.siterearnouveau.exception.DataNotFoundException;
 import org.ieeervce.api.siterearnouveau.exception.LoginFailedException;
@@ -7,14 +10,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
+import static org.ieeervce.api.siterearnouveau.controller.error.ExceptionControllerAdvice.BAD_INPUT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -57,6 +64,16 @@ class ExceptionControllerAdviceTest {
                 .andExpect(jsonPath("$.message",equalTo("Data exists")));
     }
 
+    @Test
+    void testMethodArgumentNotValidException() throws Exception {
+        mockMvc.perform(post("/methodargument").contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.ok", equalTo(false)))
+                .andExpect(jsonPath("$.response", Matchers.aMapWithSize(1)))
+                .andExpect(jsonPath("$.response.data",equalTo("must not be null")))
+                .andExpect(jsonPath("$.message",equalTo(BAD_INPUT)));
+    }
+
     @RestController
     private static class ExampleController {
         @GetMapping("/notfound1")
@@ -72,6 +89,15 @@ class ExceptionControllerAdviceTest {
         @GetMapping("/exists")
         void exists() throws DataExistsException {
             throw new DataExistsException("Data exists");
+        }
+        @PostMapping("/methodargument")
+        void exists(@Valid RequestDTO validatedRequestDTO){
+            // accept the input
+        }
+
+        private static class RequestDTO{
+            @NotNull
+            String data;
         }
 
     }

--- a/src/test/java/org/ieeervce/api/siterearnouveau/service/AuthUserDetailsServiceTest.java
+++ b/src/test/java/org/ieeervce/api/siterearnouveau/service/AuthUserDetailsServiceTest.java
@@ -89,9 +89,9 @@ class AuthUserDetailsServiceTest {
     }
 
     private User getMockUserWithUserId() {
-        User user = new User();
-        user.setUserId(USER_ID);
-        return user;
+        User mockUser = new User();
+        mockUser.setUserId(USER_ID);
+        return mockUser;
     }
 
 


### PR DESCRIPTION
Validate Input of the registration endpoint. Covering only one endpoint since this is my first time trying it.

This PR adds the necessary bean validation annotations to the DTO, and the error handling.

### Example

#### Request

```http
POST /api/auth/register
Content-Type: application/json

{
  "userId":"123456789",
  "firstName":"John",
  "lastName":"Doe",
  "password":"pass",
  "email":"Cannot even be an email",
  "role":""
}
```

#### Response

```json
{
  "ok" : false,
  "response" : {
    "password" : "length must be between 6 and 127",
    "role" : "must not be blank",
    "societyId" : "must not be null",
    "email" : "must be a well-formed email address"
  },
  "message" : "Bad Input"
}
```