### PR TITLE
Reduce to yearly builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ name: Docker
 
 on:
   schedule:
-    - cron: '28 17 * * *'
+    - cron: '28 17 2 12 *'
   push:
     branches: [ "main" ]
     # Publish semver tags as releases.


### PR DESCRIPTION
Every day is too much. Build automatically only once a year. This will ensure dependencies still work.

![Capture-001](https://github.com/user-attachments/assets/6a0cfbf8-fb5d-4e2b-972f-ec124b26d7f2)
